### PR TITLE
Suggested fix for issue 8 - expired passwords treated as failures

### DIFF
--- a/cmd/passwordspray.go
+++ b/cmd/passwordspray.go
@@ -22,7 +22,9 @@ var passwordSprayCmd = &cobra.Command{
 If no domain controller is specified, the tool will attempt to look one up via DNS SRV records.
 A full domain is required. This domain will be capitalized and used as the Kerberos realm when attempting the bruteforce.
 Succesful logins will be displayed on stdout.
-WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts`,
+WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts!
+"\1" will be replaced with the username.
+`,
 	Args:   cobra.ExactArgs(2),
 	PreRun: setupSession,
 	Run:    passwordSpray,

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -17,7 +17,8 @@ func makeSprayWorker(ctx context.Context, usernames <-chan string, wg *sync.Wait
 			if !ok {
 				return
 			}
-			testLogin(ctx, username, password)
+            password2 = ReplaceAll(password, '\1', username)
+			testLogin(ctx, username, password2)
 		}
 	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -79,6 +79,10 @@ func (k KerbruteSession) TestLogin(username, password string) (bool, error) {
 	}
 	err := Client.Login()
 	if err != nil {
+        eString := err.Error()
+		if strings.Contains(eString, "Password has expired") {
+			return true, nil
+		}
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
Suggested fix for issue 8 - now expired passwords are treated as successes.

Done! Tested 42821 logins (2334 successes) in 148.082 seconds
