### PR TITLE
added support for openbsd target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET=./dist
-ARCHS=amd64 386 
-GOOS=windows linux darwin
+ARCHS=amd64 386
+GOOS=windows linux darwin openbsd
 PACKAGENAME="github.com/ropnop/kerbrute"
 
 COMMIT=`git rev-parse --short HEAD`
@@ -19,7 +19,7 @@ LDFLAGS="-X ${PACKAGENAME}/util.GitCommit=${COMMIT} \
 -X ${PACKAGENAME}/util.Version=${VERSION} \
 "
 
-.PHONY: help windows linux mac all clean
+.PHONY: help windows linux mac openbsd all clean
 
 help:           ## Show this help.
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
@@ -38,6 +38,13 @@ linux: ## Make Linux x86 and x64 Binaries
 	done; \
 	echo "Done."
 
+openbsd: ## Make OpenBSD x86 and x64 Binaries
+	@for ARCH in ${ARCHS}; do \
+		echo "Building for openbsd $${ARCH}..." ; \
+		GOOS=openbsd GOARCH=$${ARCH} go build -a -ldflags ${LDFLAGS} -o ${TARGET}/kerbrute_openbsd_$${ARCH} || exit 1 ;\
+	done; \
+	echo "Done."
+
 mac: ## Make Darwin (Mac) x86 and x64 Binaries
 	@for ARCH in ${ARCHS}; do \
 		echo "Building for mac $${ARCH}..." ; \
@@ -50,7 +57,5 @@ clean: ## Delete any binaries
 	go clean -i -n github.com/ropnop/kerbrute ; \
 	echo "Done."
 
-all: ## Make Windows, Linux and Mac x86/x64 Binaries
-all: clean windows linux mac
-
-
+all: ## Make Windows, Linux, OpenBSD and Mac x86/x64 Binaries
+all: clean windows linux openbsd mac


### PR DESCRIPTION
Hello,

I'm mainly running OpenBSD and added support for this target. Compiled, tested, everything works fine.

```
./kerbrute_openbsd_amd64 userenum username.txt -d search.htb --dc search.htb

    __             __               __
   / /_____  _____/ /_  _______  __/ /____
  / //_/ _ \/ ___/ __ \/ ___/ / / / __/ _ \
 / ,< /  __/ /  / /_/ / /  / /_/ / /_/  __/
/_/|_|\___/_/  /_.___/_/   \__,_/\__/\___/

Version: dev (9cfb81e) - 03/29/22 - Ronnie Flathers @ropnop

2022/03/29 20:21:15 >  Using KDC(s):
2022/03/29 20:21:15 >   search.htb:88

2022/03/29 20:21:16 >  [+] VALID USERNAME:       administrator@search.htb
2022/03/29 20:21:16 >  [+] VALID USERNAME:       Administrator@search.htb
2022/03/29 20:21:19 >  [+] VALID USERNAME:       Keely.Lyons@search.htb
2022/03/29 20:21:19 >  [+] VALID USERNAME:       Sierra.Frye@search.htb
2022/03/29 20:21:19 >  [+] VALID USERNAME:       Dax.Santiago@search.htb
2022/03/29 20:21:19 >  Done! Tested 26 usernames (5 valid) in 3.673seconds
```

Thanks.