### PR TITLE
Enumeration Reliability Improvements

### DIFF
--- a/session/errors.go
+++ b/session/errors.go
@@ -21,7 +21,7 @@ func (k KerbruteSession) HandleKerbError(err error) (bool, string) {
 
 	// handle KRB errors
 	if strings.Contains(eString, "KDC_ERR_WRONG_REALM") {
-		return false, "KDC ERROR - Wrong Realm. Try adjusting the domain? Aborting..."
+		return true, "KDC ERROR - Wrong Realm. Try adjusting the domain?"
 	}
 	if strings.Contains(eString, "KDC_ERR_C_PRINCIPAL_UNKNOWN") {
 		return true, "User does not exist"
@@ -41,6 +41,9 @@ func (k KerbruteSession) HandleKerbError(err error) (bool, string) {
 	if strings.Contains(eString, "KRB_AP_ERR_SKEW Clock skew too great") {
 		return true, "Clock skew too great"
 	}
+	if strings.Contains(eString, " KDC_Error: AS Exchange Error") {
+		return true, "2FA Enabled"
+}
 
 	return false, eString
 }


### PR DESCRIPTION
Modified errors.go to not abort on the wrong domain (this does not necessarily indicate that the domain is invalid for every user, just for that user.)

Also modified errors.go to not abort when an "AS Exchange Error" occurs, as this may indicate 2FA is enabled, based off feedback in #42 . 

These two changes are allowing a user enumeration run that was previously erroring out on only a few accounts to proceed unhindered.