### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Version: dev (n/a) - 05/11/19 - Ronnie Flathers @ropnop
 You can download pre-compiled binaries for Linux, Windows and Mac from the [releases page](https://github.com/ropnop/kerbrute/releases/tag/latest). If you want to live on the edge, you can also install with Go:
 
 ```
-$ go get github.com/ropnop/kerbrute
+$ go install github.com/ropnop/kerbrute@latest
 ```
 
 With the repository cloned, you can also use the Make file to compile for common architectures:


### PR DESCRIPTION
The install command `go get` is deprecated, see: https://go.dev/doc/go-get-install-deprecation.