### PR TITLE
Add semi safe

### DIFF
--- a/cmd/kerbrute.go
+++ b/cmd/kerbrute.go
@@ -28,6 +28,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logFileName, "output", "o", "", "File to write logs to. Optional.")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Log failures and errors")
 	rootCmd.PersistentFlags().BoolVar(&safe, "safe", false, "Safe mode. Will abort if any user comes back as locked out. Default: FALSE")
+	rootCmd.PersistentFlags().IntVarP(&semiSafe, "semisafe", "", 0, "Semi-Safe mode. Will abort if more than N accounts are locked out. 0 (default) to disable")
 	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "t", 10, "Threads to use")
 	rootCmd.PersistentFlags().IntVarP(&delay, "delay", "", 0, "Delay in millisecond between each attempt. Will always use single thread if set")
 	rootCmd.PersistentFlags().BoolVar(&downgrade, "downgrade", false, "Force downgraded encryption type (arcfour-hmac-md5)")

--- a/cmd/passwordspray.go
+++ b/cmd/passwordspray.go
@@ -68,7 +68,6 @@ func passwordSpray(cmd *cobra.Command, args []string) {
 	} else {
 		scanner = bufio.NewScanner(os.Stdin)
 	}
-	
 
 	for i := 0; i < threads; i++ {
 		go makeSprayWorker(ctx, usersChan, &wg, password, userAsPass)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -15,16 +15,17 @@ var (
 	logFileName      string
 	verbose          bool
 	safe             bool
+	semiSafe         int
 	delay            int
 	threads          int
 	stopOnSuccess    bool
 	userAsPass       = false
 
-	downgrade bool
+	downgrade    bool
 	hashFileName string
 
-	logger           util.Logger
-	kSession         session.KerbruteSession
+	logger   util.Logger
+	kSession session.KerbruteSession
 
 	// Used for multithreading
 	ctx, cancel = context.WithCancel(context.Background())
@@ -39,8 +40,9 @@ func setupSession(cmd *cobra.Command, args []string) {
 		DomainController: domainController,
 		Verbose:          verbose,
 		SafeMode:         safe,
+		SemiSafeMode:     semiSafe,
 		HashFilename:     hashFileName,
-		Downgrade: downgrade,
+		Downgrade:        downgrade,
 	}
 	k, err := session.NewKerbruteSession(kOptions)
 	if err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -36,6 +36,7 @@ type KerbruteSession struct {
 	Config       *kconfig.Config
 	Verbose      bool
 	SafeMode     bool
+	SemiSafeMode	int
 	HashFile *os.File
 	Logger *util.Logger
 }
@@ -45,6 +46,7 @@ type KerbruteSessionOptions struct {
 	DomainController string
 	Verbose bool
 	SafeMode bool
+	SemiSafeMode	int
 	Downgrade bool
 	HashFilename string
 	logger *util.Logger
@@ -92,6 +94,7 @@ func NewKerbruteSession(options KerbruteSessionOptions) (k KerbruteSession, err 
 		Config:       Config,
 		Verbose:      options.Verbose,
 		SafeMode:     options.SafeMode,
+		SemiSafeMode:	options.SemiSafeMode,
 		HashFile: hashFile,
 		Logger:       options.logger,
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -36,20 +36,20 @@ type KerbruteSession struct {
 	Config       *kconfig.Config
 	Verbose      bool
 	SafeMode     bool
-	SemiSafeMode	int
-	HashFile *os.File
-	Logger *util.Logger
+	SemiSafeMode int
+	HashFile     *os.File
+	Logger       *util.Logger
 }
 
 type KerbruteSessionOptions struct {
-	Domain string
+	Domain           string
 	DomainController string
-	Verbose bool
-	SafeMode bool
-	SemiSafeMode	int
-	Downgrade bool
-	HashFilename string
-	logger *util.Logger
+	Verbose          bool
+	SafeMode         bool
+	SemiSafeMode     int
+	Downgrade        bool
+	HashFilename     string
+	logger           *util.Logger
 }
 
 func NewKerbruteSession(options KerbruteSessionOptions) (k KerbruteSession, err error) {
@@ -94,8 +94,8 @@ func NewKerbruteSession(options KerbruteSessionOptions) (k KerbruteSession, err 
 		Config:       Config,
 		Verbose:      options.Verbose,
 		SafeMode:     options.SafeMode,
-		SemiSafeMode:	options.SemiSafeMode,
-		HashFile: hashFile,
+		SemiSafeMode: options.SemiSafeMode,
+		HashFile:     hashFile,
 		Logger:       options.logger,
 	}
 	return k, err


### PR DESCRIPTION
This option tells kerberute to give up after N accounts are locked, which is slightly less safe than --safe. The main reason for this is to ignore potential preexisting lockouts, without potentially locking a whole domain.

Closes https://github.com/ropnop/kerbrute/issues/56