### PR TITLE
Pass the Hash Support for testing credentials

### DIFF
--- a/cmd/bruteforce.go
+++ b/cmd/bruteforce.go
@@ -14,7 +14,7 @@ import (
 // bruteuserCmd represents the bruteuser command
 var bruteForceCmd = &cobra.Command{
 	Use:   "bruteforce [flags] <user_pw_file>",
-	Short: "Bruteforce username:password combos, from a file or stdin",
+	Short: "Bruteforce username:password_or_hash combos, from a file or stdin",
 	Long: `Will read username and password combos from a file or stdin (format username:password) and perform a bruteforce attack using Kerberos Pre-Authentication by requesting at TGT from the KDC. Any succesful combinations will be displayed.
 If no domain controller is specified, the tool will attempt to look one up via DNS SRV records.
 A full domain is required. This domain will be capitalized and used as the Kerberos realm when attempting the bruteforce.
@@ -25,6 +25,12 @@ WARNING: failed guesses will count against the lockout threshold`,
 }
 
 func init() {
+	bruteForceCmd.Flags().StringVar(&encryptionType, "etype", "", `Specify an encryption type to use. If not specified, password(s) will be considered plaintext.
+Some of the Valid encryption types:
+rc4-hmac (NTLM)
+aes128-cts-hmac-sha1-96
+aes256-cts-hmac-sha1-96
+des-cbc-md5`)
 	rootCmd.AddCommand(bruteForceCmd)
 }
 
@@ -52,7 +58,7 @@ func bruteForceCombos(cmd *cobra.Command, args []string) {
 	}
 
 	for i := 0; i < threads; i++ {
-		go makeBruteComboWorker(ctx, combosChan, &wg)
+		go makeBruteComboWorker(ctx, combosChan, &wg, encryptionType)
 	}
 
 	start := time.Now()

--- a/cmd/bruteuser.go
+++ b/cmd/bruteuser.go
@@ -14,7 +14,7 @@ import (
 
 // bruteuserCmd represents the bruteuser command
 var bruteuserCmd = &cobra.Command{
-	Use:   "bruteuser [flags] <password_list> username",
+	Use:   "bruteuser [flags] <password_or_hash_list> username",
 	Short: "Bruteforce a single user's password from a wordlist",
 	Long: `Will perform a password bruteforce against a single domain user using Kerberos Pre-Authentication by requesting at TGT from the KDC.
 If no domain controller is specified, the tool will attempt to look one up via DNS SRV records.
@@ -26,6 +26,12 @@ WARNING: only run this if there's no lockout policy!`,
 }
 
 func init() {
+	bruteuserCmd.Flags().StringVar(&encryptionType, "etype", "", `Specify an encryption type to use. If not specified, password(s) will be considered plaintext.
+Some of the Valid encryption types:
+rc4-hmac (NTLM)
+aes128-cts-hmac-sha1-96
+aes256-cts-hmac-sha1-96
+des-cbc-md5`)
 	rootCmd.AddCommand(bruteuserCmd)
 }
 
@@ -59,7 +65,7 @@ func bruteForceUser(cmd *cobra.Command, args []string) {
 	}
 
 	for i := 0; i < threads; i++ {
-		go makeBruteWorker(ctx, passwordsChan, &wg, username)
+		go makeBruteWorker(ctx, passwordsChan, &wg, username, encryptionType)
 	}
 
 	start := time.Now()

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -19,12 +19,13 @@ var (
 	threads          int
 	stopOnSuccess    bool
 	userAsPass       = false
+	encryptionType   string
 
-	downgrade bool
+	downgrade    bool
 	hashFileName string
 
-	logger           util.Logger
-	kSession         session.KerbruteSession
+	logger   util.Logger
+	kSession session.KerbruteSession
 
 	// Used for multithreading
 	ctx, cancel = context.WithCancel(context.Background())
@@ -40,7 +41,7 @@ func setupSession(cmd *cobra.Command, args []string) {
 		Verbose:          verbose,
 		SafeMode:         safe,
 		HashFilename:     hashFileName,
-		Downgrade: downgrade,
+		Downgrade:        downgrade,
 	}
 	k, err := session.NewKerbruteSession(kOptions)
 	if err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -125,7 +125,7 @@ func (k KerbruteSession) TestLogin(username, password string, etypeName string) 
 	if etypeName != "" {
 		kt := keytab.New()
 		ts := time.Now()
-		kt.AddEntryWithHash(username, k.Realm, password, ts, 2, etypeID.RC4_HMAC)
+		kt.AddEntryWithHash(username, k.Realm, password, ts, 2, etypeID.ETypesByName[etypeName])
 
 		k.Config.LibDefaults.DefaultTktEnctypes = []string{etypeName}
 		k.Config.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.ETypesByName[etypeName]}

--- a/session/session.go
+++ b/session/session.go
@@ -2,16 +2,18 @@ package session
 
 import (
 	"fmt"
-	"github.com/ropnop/kerbrute/util"
 	"html/template"
 	"os"
 	"strings"
-
-	"github.com/ropnop/gokrb5/v8/iana/errorcode"
+	"time"
 
 	kclient "github.com/ropnop/gokrb5/v8/client"
 	kconfig "github.com/ropnop/gokrb5/v8/config"
+	"github.com/ropnop/gokrb5/v8/iana/errorcode"
+	"github.com/ropnop/gokrb5/v8/iana/etypeID"
+	keytab "github.com/ropnop/gokrb5/v8/keytab"
 	"github.com/ropnop/gokrb5/v8/messages"
+	"github.com/ropnop/kerbrute/util"
 )
 
 const krb5ConfigTemplateDNS = `[libdefaults]
@@ -36,18 +38,18 @@ type KerbruteSession struct {
 	Config       *kconfig.Config
 	Verbose      bool
 	SafeMode     bool
-	HashFile *os.File
-	Logger *util.Logger
+	HashFile     *os.File
+	Logger       *util.Logger
 }
 
 type KerbruteSessionOptions struct {
-	Domain string
+	Domain           string
 	DomainController string
-	Verbose bool
-	SafeMode bool
-	Downgrade bool
-	HashFilename string
-	logger *util.Logger
+	Verbose          bool
+	SafeMode         bool
+	Downgrade        bool
+	HashFilename     string
+	logger           *util.Logger
 }
 
 func NewKerbruteSession(options KerbruteSessionOptions) (k KerbruteSession, err error) {
@@ -92,7 +94,7 @@ func NewKerbruteSession(options KerbruteSessionOptions) (k KerbruteSession, err 
 		Config:       Config,
 		Verbose:      options.Verbose,
 		SafeMode:     options.SafeMode,
-		HashFile: hashFile,
+		HashFile:     hashFile,
 		Logger:       options.logger,
 	}
 	return k, err
@@ -118,8 +120,22 @@ func buildKrb5Template(realm, domainController string) string {
 	return builder.String()
 }
 
-func (k KerbruteSession) TestLogin(username, password string) (bool, error) {
-	Client := kclient.NewWithPassword(username, k.Realm, password, k.Config, kclient.DisablePAFXFAST(true), kclient.AssumePreAuthentication(true))
+func (k KerbruteSession) TestLogin(username, password string, etypeName string) (bool, error) {
+	var Client *kclient.Client = nil
+	if etypeName != "" {
+		kt := keytab.New()
+		ts := time.Now()
+		kt.AddEntryWithHash(username, k.Realm, password, ts, 2, etypeID.RC4_HMAC)
+
+		k.Config.LibDefaults.DefaultTktEnctypes = []string{etypeName}
+		k.Config.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.ETypesByName[etypeName]}
+		k.Config.LibDefaults.DefaultTGSEnctypes = []string{etypeName}
+		k.Config.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.ETypesByName[etypeName]}
+
+		Client = kclient.NewWithKeytab(username, k.Realm, kt, k.Config, kclient.DisablePAFXFAST(true), kclient.AssumePreAuthentication(true), kclient.SetpreAuthEType(etypeID.ETypesByName[etypeName]))
+	} else {
+		Client = kclient.NewWithPassword(username, k.Realm, password, k.Config, kclient.DisablePAFXFAST(true), kclient.AssumePreAuthentication(true))
+	}
 	defer Client.Destroy()
 	if ok, err := Client.IsConfigured(); !ok {
 		return false, err


### PR DESCRIPTION
- Modified `session/TestLogin()` function to support taking precomputed hash and creating a client with  `Client.NewWithKeytab`.
- Added a flag `etype` that specifies the hashing algorithm that the password or password list should be treated as precomputed.
- Modified `gokrb5` to support adding entries to keytab with precomputed hash.[ropnop/gokrb5/PR](https://github.com/ropnop/gokrb5/pull/2)

I'm still going through how things work out so I can polish out code. I don't know a lot about how kerberos works authentication works in detail. Like I've yet to figure out why it expected a KVNO of 2 and why hardcoding it worked.

I'm still looking into if there is any better way  to set the options to use etype than to set defaults in `k.Config.LibDefaults.` 

Tested this against APT machine on hackthebox  and it seems to work smoothly for `rc4-hmac`.

resolves #38